### PR TITLE
error handling for term archive titles

### DIFF
--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -441,9 +441,9 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			} elseif ( is_author() ) {
 				$key = 'archive_author_title';
 			} elseif ( is_category() || is_tag() || is_tax() ) {
-				if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
+				if ( get_queried_object() && ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
 					return $option['title'];
-				} else {
+				} elseif ( ! empty( $taxonomy ) ) {
 					$key = "archive_{$taxonomy}_title";
 				}
 			} elseif ( is_post_type_archive() ) {

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -441,9 +441,9 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 			} elseif ( is_author() ) {
 				$key = 'archive_author_title';
 			} elseif ( is_category() || is_tag() || is_tax() ) {
-				if ( get_queried_object() && ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
+				if ( ( WP_SEO_Settings()->has_term_fields( $taxonomy = get_queried_object()->taxonomy ) ) && ( $option = get_option( $this->get_term_option_name( get_queried_object() ) ) ) && ( ! empty( $option['title'] ) ) ) {
 					return $option['title'];
-				} elseif ( ! empty( $taxonomy ) ) {
+				} else {
 					$key = "archive_{$taxonomy}_title";
 				}
 			} elseif ( is_post_type_archive() ) {

--- a/php/class-wp-seo.php
+++ b/php/class-wp-seo.php
@@ -430,6 +430,11 @@ if ( ! class_exists( 'WP_SEO' ) ) :
 		 *                       custom or formatted title exists.
 		 */
 		public function wp_title( $title, $sep ) {
+			// If we're generating RSS feed output, no page title is necessary.
+			if ( is_feed() ) {
+				return $title;
+			}
+
 			if ( is_singular() ) {
 				if ( WP_SEO_Settings()->has_post_fields( $post_type = get_post_type() ) && $meta_title = get_post_meta( get_the_ID(), '_meta_title', true ) ) {
 					return $meta_title;


### PR DESCRIPTION
It is possible for a request URL to ask for an RSS feed for a nonexistent taxonomy term. This generates an empty RSS feed. When that happens, the WP SEO plugin tries to filter the page title, but because the taxonomy term does not exist, the call to `get_queried_object` returns `null` and the attempt to get the taxonomy name from that `null` throws a warning.

This PR avoids that warning by checking if we're generating an RSS feed, and if so, just returning the `$title` and not taking the filter any further.

⚠️ See [the PR that spawned this PR](https://github.com/wpcomvip/mit-technology-review/pull/781) for details on why this PR exists.